### PR TITLE
Some script fixes.

### DIFF
--- a/micro-suite/compile-all
+++ b/micro-suite/compile-all
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cmake --toolchain ~/wasm-ndk/wasm_ndk/cmake/toolchain/android_wasm.toolchain.cmake .
+cmake --build .
+
+./wasm2c-all $@
+./final-compile-all $@

--- a/micro-suite/compile-and-push-all
+++ b/micro-suite/compile-and-push-all
@@ -1,8 +1,4 @@
 #!/bin/sh
 
-cmake --toolchain ~/wasm-ndk/wasm_ndk/cmake/toolchain/android_wasm.toolchain.cmake .
-cmake --build .
-
-./wasm2c-all $@
-./final-compile-all $@
+./compile-all $@
 ./push-all $@

--- a/micro-suite/final-compile-all
+++ b/micro-suite/final-compile-all
@@ -19,10 +19,13 @@ for stem in $stems; do
     echo No $stem.c or $stem.cpp found >&2
     exit 1
   fi
-  echo ~/AW/wabt/bin/wasm2c --experimental --enable-memory64 --disable-sandbox ${stem}.wasm -o ${stem}.wasm.c
-  ~/AW/wabt/bin/wasm2c --experimental --enable-memory64 --disable-sandbox ${stem}.wasm -o ${stem}.wasm.c
-  echo $ANDROID_CLANG_TOOLCHAIN/bin/clang -Wno-incompatible-library-redeclaration -Wno-builtin-requires-header -I ~/AW/wabt/wasm2c --target=aarch64-linux-android29 --sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot -O3 -g $extralib ${stem}.wasm.c -o $stem
-  $ANDROID_CLANG_TOOLCHAIN/bin/clang -Wno-incompatible-library-redeclaration -Wno-builtin-requires-header -I ~/AW/wabt/wasm2c --target=aarch64-linux-android29 --sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot -O3 -g $extralib ${stem}.wasm.c -o $stem
+  if [ -r ${stem}.wasm.c ]; then
+    echo $ANDROID_CLANG_TOOLCHAIN/bin/clang -Wno-incompatible-library-redeclaration -Wno-builtin-requires-header -I ~/AW/wabt/wasm2c --target=aarch64-linux-android29 --sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot -O3 -g $extralib ${stem}.wasm.c -o $stem
+    $ANDROID_CLANG_TOOLCHAIN/bin/clang -Wno-incompatible-library-redeclaration -Wno-builtin-requires-header -I ~/AW/wabt/wasm2c --target=aarch64-linux-android29 --sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot -O3 -g $extralib ${stem}.wasm.c -o $stem
+  else
+    echo Missing ${stem}.wasm.c >&2
+    exit 1
+  fi
   echo $ANDROID_CLANG_TOOLCHAIN/bin/${ccmd} -Wno-incompatible-library-redeclaration -Wno-builtin-requires-header -I ~/AW/wabt/wasm2c --target=aarch64-linux-android29 --sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot -O3 -g $src -o ${stem}-native
   $ANDROID_CLANG_TOOLCHAIN/bin/${ccmd} -Wno-incompatible-library-redeclaration -Wno-builtin-requires-header -I ~/AW/wabt/wasm2c --target=aarch64-linux-android29 --sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot -O3 -g $src -o ${stem}-native
 done


### PR DESCRIPTION
Removes unnecessary wasm2c step in final-compile-all (since running wasm2c-all beforehand is assumed).
New compile-all that does all compile steps but no adb push.