### PR TITLE
Typo in push-all script.

### DIFF
--- a/micro-suite/push-all
+++ b/micro-suite/push-all
@@ -11,6 +11,6 @@ for stem in $stems; do
   progs="$progs $stem ${stem}-native"
 done
 
-extras="$ANDROID_CLANG_TOOLCHAIN/android_libc++/ndk/aarch65/lib/libc++_shared.so all-progs time-all"
+extras="$ANDROID_CLANG_TOOLCHAIN/android_libc++/ndk/aarch64/lib/libc++_shared.so all-progs time-all"
 
 adb push $extras $progs /data/local/tmp


### PR DESCRIPTION
Just fixing a typo in the path for the libc++ .so file.