### PR TITLE
Some flag and script tweaks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(-O3)
 if (ANDROID_WASM)
   add_link_options(-Wl,--export=__main_argc_argv)
   add_link_options(-Wl,--strip-debug)
-  add_compile_options(-fno-unroll-loops)
+  #  add_compile_options(-fno-unroll-loops)
 endif()
 
 add_executable(164.gzip

--- a/micro-suite/CMakeLists.txt
+++ b/micro-suite/CMakeLists.txt
@@ -7,7 +7,7 @@ set(BENCHES_SRC_PATH ".")
 add_compile_options(-Wno-implicit-function-declaration)
 add_compile_options(-fvisibility=default)
 add_compile_options(-O3)
-add_compile_options(-fno-unroll-loops)
+#add_compile_options(-fno-unroll-loops)
 
 # For wasm-ld only
 if (ANDROID_WASM)

--- a/micro-suite/compile-all
+++ b/micro-suite/compile-all
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-cmake --toolchain ~/wasm-ndk/wasm_ndk/cmake/toolchain/android_wasm.toolchain.cmake .
+: ${WASM_NDK:=../../wasm_ndk}
+
+cmake --toolchain $WASM_NDK/cmake/toolchain/android_wasm.toolchain.cmake .
 cmake --build .
 
 ./wasm2c-all $@


### PR DESCRIPTION
Don't specify -fno-unroll-loops during the C(++)->WASM step. Provide environment variable WASM_NDK to point to the location of the modified NDK when running the scripts under micro-suite.