### PR TITLE
Use printf directly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,3 @@ add_executable(164.gzip
     ${SPEC_164_GZIP_PATH}/unzip.c
     ${SPEC_164_GZIP_PATH}/util.c
     ${SPEC_164_GZIP_PATH}/zip.c)
-
-if (ANDROID_WASM)
-  target_sources(164.gzip PRIVATE
-      ${WASM_LIBRARY_PATH}/open-proxy.c
-      ${WASM_LIBRARY_PATH}/standalone-printf.c)
-endif()

--- a/micro-suite/CMakeLists.txt
+++ b/micro-suite/CMakeLists.txt
@@ -16,41 +16,31 @@ if (ANDROID_WASM)
 endif()
 
 add_executable(memops.wasm
-    ${BENCHES_SRC_PATH}/memops.c
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/memops.c)
 
 add_executable(primes.wasm
-    ${BENCHES_SRC_PATH}/primes.c
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/primes.c)
 
 add_executable(fannkuch.wasm
-    ${BENCHES_SRC_PATH}/fannkuch.c
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/fannkuch.c)
 
 add_executable(conditionals.wasm
-    ${BENCHES_SRC_PATH}/conditionals.c
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/conditionals.c)
 
 add_executable(copy.wasm
-    ${BENCHES_SRC_PATH}/copy.cpp
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/copy.cpp)
 
 add_executable(corrections.wasm
-    ${BENCHES_SRC_PATH}/corrections.c
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/corrections.c)
 
 add_executable(corrections64.wasm
-    ${BENCHES_SRC_PATH}/corrections64.c
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/corrections64.c)
 
 add_executable(fasta.wasm
-    ${BENCHES_SRC_PATH}/fasta.cpp
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/fasta.cpp)
 
 add_executable(ifs.wasm
-    ${BENCHES_SRC_PATH}/ifs.c
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/ifs.c)
 
 add_executable(skinning.wasm
-    ${BENCHES_SRC_PATH}/skinning.cpp
-    ${WASM_LIBRARY_PATH}/standalone-printf.c)
+    ${BENCHES_SRC_PATH}/skinning.cpp)


### PR DESCRIPTION
Removes the use of standalone-printf.c since varargs calls are now supported.